### PR TITLE
Fix workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,5 +7,7 @@ tag = True
 
 [bumpversion:file:docker-compose.yml]
 
+[bumpversion:file:CMakeLists.txt]
+
 [bumpversion:file:cmake_docker.cpp]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: required
+sudo: false
+distro: trusty
 
 services:
   - docker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9.1)
 project(cmake_docker)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM gcc:7
 
 RUN apt-get purge -y cmake
 
-RUN mkdir /tmp/cmake && \
-    cd /tmp/cmake && \
-    wget https://cmake.org/files/v3.9/cmake-3.9.1.tar.gz && \
-    tar -xzvf cmake-3.9.1.tar.gz
+WORKDIR /tmp/cmake
+RUN wget https://cmake.org/files/v3.9/cmake-3.9.1.tar.gz && \
+    tar -xzvf cmake-3.9.1.tar.gz > /dev/null
 
-RUN cd /tmp/cmake/cmake-3.9.1/ && \
-    ./bootstrap && \
+WORKDIR cmake-3.9.1
+RUN ./bootstrap && \
     make -j4 && \
     make install
 
+WORKDIR /
 RUN rm -rf /tmp/cmake

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,8 @@
 set -ex
 
 cmake --version
-cmake -G "CodeBlocks - Unix Makefiles" .
-cmake --build . --target all -- -j 2
+mkdir build
+cd build
+cmake ..
+make -j4
 ./cmake_docker


### PR DESCRIPTION
* Added `bumpversion` support for test project's **CMakeLists.txt**.
* Added `WORKDIR` to **Dockerfile** instead of `mkdir` + `cd`.
* Using non-`sudo` distributive for `Travis CI`, should speed up builds invocation.
